### PR TITLE
Refactor hero widget layout to use CSS Grid

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -121,7 +121,7 @@ export default function Hero() {
                 key={i}
                 className="animate-depth-in h-48 w-48 rounded-lg"
                 style={{
-                  animationDelay: `${i * 0.05}s`,
+                  animationDelay: `${i * 0.1}s`,
                   transform: `translate(${randomOffsets[i]?.[0] || 0}px, ${
                     randomOffsets[i]?.[1] || 0
                   }px)`,


### PR DESCRIPTION
Fixes #9

- Removed duplicate Stocks04 widget from the hero section
- Removed hardcoded position classes array
- Migrated from absolute positioning to CSS Grid (6 columns, gap-8)
- Updated container to use flex-col for better alignment